### PR TITLE
Handle received STOMP frames that contain a trailing LF character

### DIFF
--- a/lib/resty/rabbitmqstomp.lua
+++ b/lib/resty/rabbitmqstomp.lua
@@ -20,6 +20,7 @@ _VERSION = "0.1"
 
 local mt = { __index = _M }
 
+local LF = "\x0a"
 local EOL = "\x0d\x0a"
 local NULL_BYTE = "\x00"
 local STATE_CONNECTED = 1
@@ -33,7 +34,7 @@ function new(self, opts)
     end
     
     if opts == nil then
-	opts = {username = "guest", password = "guest", vhost = "/"}
+	opts = {username = "guest", password = "guest", vhost = "/", trailing_lf = true}
     end
      
     return setmetatable({ sock = sock, opts = opts}, mt)
@@ -91,7 +92,12 @@ function _receive_frame(self)
     if not sock then
         return nil, "not initialized"
     end
-    local resp = sock:receiveuntil(NULL_BYTE, {inclusive = true})
+    local resp = nil
+    if self.opts.trailing_lf == nil or self.opts.trailing_lf == true then
+        resp = sock:receiveuntil(NULL_BYTE .. LF, {inclusive = true})
+    else
+        resp = sock:receiveuntil(NULL_BYTE, {inclusive = true})
+    end
     local data, err, partial = resp()
     return data, err
 end


### PR DESCRIPTION
Starting with RabbitMQ 3.5.4, the rabbitmq-stomp plugin terminates frames using a newline (LF) character:
https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v3_5_4

However, this change broke a number of third-party libraries, one of them being this one:
https://groups.google.com/forum/#!topic/rabbitmq-users/TGLg3ixAD8Y

This is most evident when using a connection pool - when trying to release a connection back into the pool after using it, we receive the error _unread data in buffer_.

In order to fix the issue, we change the default behaviour of the library to look for a newline character after the null byte when receiving a frame. The original behavior can be restored (for backwards compatibility with earlier RabbitMQ versions) by setting a new _trailing_lf_ parameter to _false_ in the connection options.

Related: https://github.com/rabbitmq/rabbitmq-stomp/issues/38
