### PR TITLE
Restore missing login header in CONNECT frame

### DIFF
--- a/lib/resty/rabbitmqstomp.lua
+++ b/lib/resty/rabbitmqstomp.lua
@@ -107,7 +107,7 @@ function _login(self)
     
     local headers = {}
     headers["accept-version"] = "1.2"
-    headers["login"] = self.opts.user
+    headers["login"] = self.opts.username
     headers["passcode"] = self.opts.password
     headers["host"] = self.opts.vhost
 


### PR DESCRIPTION
The CONNECT frame is missing the login header due to a typo, this patch restores it.

This was previously fixed in PR #4 but seems to have been accidentally reverted.
