### PR TITLE
Check the response to the CONNECT frame to see if there was an error

### DIFF
--- a/lib/resty/rabbitmqstomp.lua
+++ b/lib/resty/rabbitmqstomp.lua
@@ -116,8 +116,18 @@ function _login(self)
         return nil, err
     end
 
+    local frame, err = _receive_frame(self)
+    if not frame then
+        return nil, err
+    end
+
+    -- We successfully received a frame, but it was an ERROR frame
+    if sub( frame, 1, len( 'ERROR' ) ) == 'ERROR' then
+        return nil, frame
+    end
+
     self.state = STATE_CONNECTED
-    return _receive_frame(self)
+    return frame
 end
 
 


### PR DESCRIPTION
When establishing a connection to RabbitMQ, we need to inspect the frame sent in response to the CONNECT frame. If this frame is an ERROR frame, return the error message to the end-user. This allows the user to trap login errors, such as missing headers or an invalid username/password.
